### PR TITLE
Only show SOAAP related options with --help

### DIFF
--- a/tools/soaap.cpp
+++ b/tools/soaap.cpp
@@ -49,6 +49,7 @@
 #include <algorithm>
 #include <memory>
 #include "Passes/Soaap.h"
+#include "Common/CmdLineOpts.h"
 
 using namespace llvm;
 
@@ -93,6 +94,7 @@ int main(int argc, char **argv) {
   initializeTarget(Registry);
   initializeSoaapPass(Registry);
 
+  cl::HideUnrelatedOptions(soaap::CmdLineOpts::SoaapCategory);
   cl::ParseCommandLineOptions(argc, argv,
     "llvm .bc -> .bc modular optimizer and analysis printer\n");
 


### PR DESCRIPTION
Not sure if any of the generic clang/llvm command line options are useful