### PR TITLE
Convert libxo module to pull directly from GitHub.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libxo"]
-	path = libxo
-	url = https://github.com/Juniper/libxo.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fno-rtti -std=c++11")
 # libxo
 include(ExternalProject)
 ExternalProject_Add(libxo
-  URL ${CMAKE_CURRENT_SOURCE_DIR}/libxo
+  GIT_REPOSITORY https://github.com/Juniper/libxo.git
+  GIT_TAG 0.1.6
   BUILD_IN_SOURCE 1
   CONFIGURE_COMMAND rm -rf configure m4
                     COMMAND sh bin/setup.sh


### PR DESCRIPTION
Rather than including the libxo sources as a SOAAP submodule, teach
SOAAP's CMake infrastructure how to download libxo with tag 0.1.6.

On a separate note, we might want to update to a more recent libxo at some
point. At the very least, it would be convenient to use exactly the
same version as FreeBSD.