### PR TITLE
Fix CMake build issue /bin/clang++ not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,26 @@ if (NOT CMAKE_VERSION VERSION_LESS 2.8.12)
 endif()
 
 # Allow user to optionally override LLVM build tree locations.
+set(LLVM_BUILD_DIR "" CACHE PATH "Path to LLVM build directory")
 set(LLVM_TOOLS_BINARY_DIR "" CACHE PATH "Path to llvm/bin")
 set(LLVM_LIBRARY_DIR "" CACHE PATH "Path to llvm/lib")
 set(LLVM_MAIN_INCLUDE_DIR "" CACHE PATH "Path to llvm/include")
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM build tree")
 set(LLVM_MAIN_SRC_DIR "" CACHE PATH "Path to LLVM source tree")
 
-find_package(LLVM REQUIRED NO_CMAKE_PATH) # config mode search
-message(STATUS "Found LLVM: ${LLVM_DIR}")
+if(NOT LLVM_BUILD_DIR)
+  # compatibility with the previous build instructions
+  if(LLVM_DIR)
+    set(LLVM_BUILD_DIR "${LLVM_DIR}/../../..")
+  else()
+    message(FATAL_ERROR "LLVM_BUILD_DIR not defined! It must point to the directory where LLVM was built.")
+  endif()
+endif()
+# only search in ${LLVM_BUILD_DIR} and not in any of the default search locations:
+# this is done by passing PATHS ${LLVM_DIR} and NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH
+# message("Looking for LLVM in ${LLVM_BUILD_DIR}")
+find_package(LLVM REQUIRED CONFIG PATHS ${LLVM_BUILD_DIR} NO_DEFAULT_PATH)
+message(STATUS "Found LLVM: ${LLVM_BUILD_BINARY_DIR}")
 
 foreach(v
     TOOLS_BINARY_DIR
@@ -23,8 +35,11 @@ foreach(v
     BINARY_DIR
     MAIN_SRC_DIR
     )
-  if(LLVM_BUILD_${v} AND NOT LLVM_${v})
-    set(LLVM_${v} "${LLVM_BUILD_${v}}")
+  if (LLVM_${v})
+    set(LLVM_BUILD_${v} "${LLVM_${v}}")
+  endif()
+  if(NOT LLVM_BUILD_${v})
+    message(FATAL_ERROR "Required variable LLVM_BUILD_${v} is not set!")
   endif()
 endforeach()
 
@@ -36,10 +51,13 @@ list(APPEND CMAKE_MODULE_PATH "${LLVM_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/m
 include(AddLLVM)
 add_definitions(${LLVM_DEFINITIONS})
 
-set(CMAKE_C_COMPILER ${LLVM_BINARY_DIR}/bin/clang CACHE FILE "C compiler" FORCE)
-set(CMAKE_CXX_COMPILER ${LLVM_BINARY_DIR}/bin/clang++ CACHE FILE "C++ compiler" FORCE)
-message(STATUS "Setting C compiler to ${CMAKE_C_COMPILER}")
-message(STATUS "Setting C++ compiler to ${CMAKE_CXX_COMPILER}")
+# LLVM_BINARY_DIR must be set otherwise there would have been an error earlier
+if(NOT ${CMAKE_C_COMPILER} STREQUAL "${LLVM_TOOLS_BINARY_DIR}/clang")
+  set(CMAKE_C_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang CACHE FILE "C compiler" FORCE)
+  set(CMAKE_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang++ CACHE FILE "C++ compiler" FORCE)
+  message(STATUS "Setting C compiler to ${CMAKE_C_COMPILER}")
+  message(STATUS "Setting C++ compiler to ${CMAKE_CXX_COMPILER}")
+endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fno-rtti -std=c++11")
@@ -88,15 +106,13 @@ endif()
 set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin)
 set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib)
 
-set(LIT ${LLVM_BINARY_DIR}/bin/llvm-lit CACHE FILE "Location of llvm-lit")
+set(LIT ${LLVM_BUILD_BINARY_DIR}/bin/llvm-lit CACHE FILE "Location of llvm-lit")
 
-include_directories(${LLVM_MAIN_INCLUDE_DIR})
+include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${LLVM_MAIN_SRC_DIR}/lib)
 include_directories(${LLVM_MAIN_SRC_DIR}/runtime/libprofile)
-include_directories(${LLVM_BINARY_DIR}/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/soaap)
-link_directories(${LLVM_LIBRARY_DIR})
 
 add_subdirectory(include)
 add_subdirectory(soaap)

--- a/cmake/modules/FindLibCXX.cmake
+++ b/cmake/modules/FindLibCXX.cmake
@@ -41,5 +41,10 @@ find_package_handle_standard_args(LIBCXX DEFAULT_MSG
   LIBCXX_LIBRARY
   LIBCXX_INCLUDE_DIRS
 )
+if(NOT EXISTS "${LIBCXX_INCLUDE_DIR}/cxxabi.h")
+  # work around systems that have libc++ but only the libcstdc++ <cxxabi.h> header
+  message(WARNING "libc++ found but required header cxxabi.h doesn't exist! libc++ does not seem to be installed correctly!")
+  set(LIBCXX_FOUND FALSE)
+endif()
 
 mark_as_advanced (LIBCXX_INCLUDE_DIRS)


### PR DESCRIPTION
After some CMake runs it would reset CMAKE_CXX_COMPILER to
${LLVM_BINARY_DIR}/bin/clang++, but for some reason ${LLVM_BINARY_DIR}
would be empty and it would try and use /bin/clang++ which doesn't
exist. I got bitten by this issue a few times, this should fix it.

Not sure if this might break the build for others so I created this pull request.
Fresh build recommended.
Also it is now possible to pass -DLLVM_BUILD_DIR=`pwd/../../llvm/build` (i.e. without the /share/cmake/llvm) to CMake.